### PR TITLE
[add] Implement `didDisplayIncomingCall` method call

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/Constants.java
+++ b/android/src/main/java/io/wazo/callkeep/Constants.java
@@ -1,6 +1,7 @@
 package io.wazo.callkeep;
 
 public class Constants {
+    public static final String ACTION_DISPLAY_INCOMING = "ACTION_DISPLAY_INCOMING";
     public static final String ACTION_ANSWER_CALL = "ACTION_ANSWER_CALL";
     public static final String ACTION_AUDIO_SESSION = "ACTION_AUDIO_SESSION";
     public static final String ACTION_CHECK_REACHABILITY = "ACTION_CHECK_REACHABILITY";
@@ -16,4 +17,9 @@ public class Constants {
     public static final String EXTRA_CALL_NUMBER = "EXTRA_CALL_NUMBER";
     public static final String EXTRA_CALL_UUID = "EXTRA_CALL_UUID";
     public static final String EXTRA_CALLER_NAME = "EXTRA_CALLER_NAME";
+    public static final String EXTRA_CALLER_HANDLE = "EXTRA_CALLER_HANDLE";
+    public static final String EXTRA_CALL_HANDLE_TYPE = "EXTRA_CALL_HANDLE_TYPE";
+    public static final String EXTRA_CALL_HAS_VIDEO = "EXTRA_CALL_HAS_VIDEO";
+    public static final String EXTRA_CALL_FROM_PUSHKIT = "EXTRA_CALL_FROM_PUSHKIT";
+    public static final String EXTRA_CALL_PAYLOAD = "EXTRA_CALL_PAYLOAD";
 }

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static io.wazo.callkeep.Constants.ACTION_DISPLAY_INCOMING;
 import static io.wazo.callkeep.Constants.ACTION_AUDIO_SESSION;
 import static io.wazo.callkeep.Constants.ACTION_ONGOING_CALL;
 import static io.wazo.callkeep.Constants.ACTION_CHECK_REACHABILITY;
@@ -118,12 +119,16 @@ public class VoiceConnectionService extends ConnectionService {
 
     @Override
     public Connection onCreateIncomingConnection(PhoneAccountHandle connectionManagerPhoneAccount, ConnectionRequest request) {
-        Bundle extra = request.getExtras();
+        Bundle extras = request.getExtras();
         Uri number = request.getAddress();
-        String name = extra.getString(EXTRA_CALLER_NAME);
+        String name = extras.getString(EXTRA_CALLER_NAME);
         Connection incomingCallConnection = createConnection(request);
         incomingCallConnection.setRinging();
         incomingCallConnection.setInitialized();
+        HashMap<String, String> extrasMap = this.bundleToMap(extras);
+        extrasMap.put(Constants.EXTRA_CALLER_HANDLE, number.toString());
+        extrasMap.put(Constants.EXTRA_CALL_FROM_PUSHKIT, "false");
+        sendCallRequestToActivity(ACTION_DISPLAY_INCOMING, extrasMap);
 
         return incomingCallConnection;
     }

--- a/android/src/main/kotlin/co/doneservices/callkeep/CallKeep.kt
+++ b/android/src/main/kotlin/co/doneservices/callkeep/CallKeep.kt
@@ -40,10 +40,9 @@ private fun isConnectionServiceAvailable(): Boolean {
 }
 
 class CallKeep(private val channel: MethodChannel, private var applicationContext: Context) : MethodChannel.MethodCallHandler, PluginRegistry.RequestPermissionsResultListener {
-    companion object {
-        var isReceiverRegistered = false
-    }
     internal var currentActivity: Activity? = null
+
+    private var isReceiverRegistered = false
 
     private var hasPhoneAccountResult: MethodChannel.Result? = null
     private var voiceBroadcastReceiver: VoiceBroadcastReceiver? = null
@@ -172,10 +171,8 @@ class CallKeep(private val channel: MethodChannel, private var applicationContex
 
         if (isConnectionServiceAvailable()) {
             registerPhoneAccount(applicationContext, imageName)
-            if (!isReceiverRegistered) {
-                voiceBroadcastReceiver = VoiceBroadcastReceiver()
-                registerReceiver()
-            }
+            voiceBroadcastReceiver = VoiceBroadcastReceiver()
+            registerReceiver()
             VoiceConnectionService.setPhoneAccountHandle(handle)
             VoiceConnectionService.setAvailable(true)
         }

--- a/android/src/main/kotlin/co/doneservices/callkeep/CallKeep.kt
+++ b/android/src/main/kotlin/co/doneservices/callkeep/CallKeep.kt
@@ -40,9 +40,10 @@ private fun isConnectionServiceAvailable(): Boolean {
 }
 
 class CallKeep(private val channel: MethodChannel, private var applicationContext: Context) : MethodChannel.MethodCallHandler, PluginRegistry.RequestPermissionsResultListener {
+    companion object {
+        var isReceiverRegistered = false
+    }
     internal var currentActivity: Activity? = null
-
-    private var isReceiverRegistered = false
 
     private var hasPhoneAccountResult: MethodChannel.Result? = null
     private var voiceBroadcastReceiver: VoiceBroadcastReceiver? = null
@@ -69,7 +70,7 @@ class CallKeep(private val channel: MethodChannel, private var applicationContex
                 result.success(null)
             }
             "displayIncomingCall" -> {
-                displayIncomingCall(call.argument("uuid")!!, call.argument("number"), call.argument("callerName"))
+                displayIncomingCall(call.argument("uuid")!!, call.argument("number"), call.argument("callerName"), call.argument("handleType"), call.argument("hasVideo"), call.argument("payload"))
                 result.success(null)
             }
             "answerIncomingCall" -> {
@@ -171,22 +172,27 @@ class CallKeep(private val channel: MethodChannel, private var applicationContex
 
         if (isConnectionServiceAvailable()) {
             registerPhoneAccount(applicationContext, imageName)
-            voiceBroadcastReceiver = VoiceBroadcastReceiver()
-            registerReceiver()
+            if (!isReceiverRegistered) {
+                voiceBroadcastReceiver = VoiceBroadcastReceiver()
+                registerReceiver()
+            }
             VoiceConnectionService.setPhoneAccountHandle(handle)
             VoiceConnectionService.setAvailable(true)
         }
     }
 
-    private fun displayIncomingCall(uuid: String, number: String?, callerName: String?) {
+    private fun displayIncomingCall(uuid: String, number: String?, callerName: String?, handleType: String?, hasVideo: Boolean?, payload: String?) {
         if (!isConnectionServiceAvailable() || !hasPhoneAccount()) return
 
-        Log.d(TAG, "displayIncomingCall number: $number, callerName: $callerName")
+        Log.d(TAG, "displayIncomingCall number: $number, callerName: $callerName, handleType: $handleType, hasVideo: $hasVideo")
         val extras = Bundle()
         val uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, number, null)
         extras.putParcelable(TelecomManager.EXTRA_INCOMING_CALL_ADDRESS, uri)
         extras.putString(Constants.EXTRA_CALLER_NAME, callerName)
         extras.putString(Constants.EXTRA_CALL_UUID, uuid)
+        extras.putString(Constants.EXTRA_CALL_HANDLE_TYPE, handleType)
+        extras.putString(Constants.EXTRA_CALL_HAS_VIDEO, hasVideo.toString())
+        extras.putString(Constants.EXTRA_CALL_PAYLOAD, payload)
         telecomManager!!.addNewIncomingCall(handle, extras)
     }
 
@@ -500,6 +506,7 @@ class CallKeep(private val channel: MethodChannel, private var applicationContex
         if (isReceiverRegistered) return
 
         val intentFilter = IntentFilter()
+        intentFilter.addAction(Constants.ACTION_DISPLAY_INCOMING)
         intentFilter.addAction(Constants.ACTION_END_CALL)
         intentFilter.addAction(Constants.ACTION_ANSWER_CALL)
         intentFilter.addAction(Constants.ACTION_MUTE_CALL)
@@ -534,6 +541,16 @@ class CallKeep(private val channel: MethodChannel, private var applicationContex
                 Constants.ACTION_ANSWER_CALL -> {
                     channel.invokeMethod("performAnswerCallAction", hashMapOf(
                             "callUUID" to attributeMap?.get(Constants.EXTRA_CALL_UUID)
+                    ))
+                }
+                Constants.ACTION_DISPLAY_INCOMING -> {
+                    channel.invokeMethod("didDisplayIncomingCall", hashMapOf(
+                            "callUUID" to attributeMap?.get(Constants.EXTRA_CALL_UUID),
+                            "handle" to attributeMap?.get(Constants.EXTRA_CALLER_HANDLE),
+                            "localizedCallerName" to attributeMap?.get(Constants.EXTRA_CALLER_NAME),
+                            "hasVideo" to attributeMap?.get(Constants.EXTRA_CALL_HAS_VIDEO),
+                            "fromPushKit" to attributeMap?.get(Constants.EXTRA_CALL_FROM_PUSHKIT),
+                            "payload" to attributeMap?.get(Constants.EXTRA_CALL_PAYLOAD)
                     ))
                 }
                 Constants.ACTION_HOLD_CALL -> {

--- a/lib/flutter_callkeep.dart
+++ b/lib/flutter_callkeep.dart
@@ -175,7 +175,7 @@ class CallKeep {
   }
 
   /// Display system UI for incoming calls
-  static Future<void> displayIncomingCall(String uuid, [String number, String callerName, HandleType handleType, bool hasVideo]) async {
+  static Future<void> displayIncomingCall(String uuid, [String number, String callerName, HandleType handleType, bool hasVideo, String payload]) async {
     assert(uuid != null);
 
     await _channel.invokeMethod('displayIncomingCall', {
@@ -184,6 +184,7 @@ class CallKeep {
       'callerName': callerName,
       'handleType': describeEnum(handleType),
       'hasVideo': hasVideo,
+      'payload': payload,
     });
   }
 

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -33,13 +33,15 @@ class DidDisplayIncomingCallEvent {
   final String localizedCallerName;
   final bool hasVideo;
   final bool fromPushKit;
+  final String payload;
 
   DidDisplayIncomingCallEvent._new(Map<dynamic, dynamic> arguments)
       : this.callUUID = arguments['callUUID'],
         this.handle = arguments['handle'],
         this.localizedCallerName = arguments['localizedCallerName'],
-        this.hasVideo = arguments['hasVideo'],
-        this.fromPushKit = arguments['fromPushKit'];
+        this.hasVideo = arguments['hasVideo'] == 'true',
+        this.fromPushKit = arguments['fromPushKit'] == 'true',
+        this.payload = arguments['payload'];
 }
 
 class DidPerformSetMutedCallAction {


### PR DESCRIPTION
## Explanation

I was wondering about the `didDisplayIncomingCall` event not firing and looked it up, but it wasn't implemented.
So we implemented it so that the `didDisplayIncomingCall` event fires when the user executes a `displayIncomingCall`.
~I also prevented the `VoiceBroadcastReceiver` from being configured twice when the user ran `CallKeep.setup()` twice.~ https://github.com/doneservices/flutter_callkeep/pull/14#issuecomment-645104936

## What I did

- Implement `didDisplayIncomingCall` method call
~- Prevent to re-configure `VoiceBroadcastReceiver` when user executes `CallKeep.setup() twice`~ https://github.com/doneservices/flutter_callkeep/pull/14#issuecomment-645104936
- Add optional parameters to `displayIncomingCall`

## Operation check

| foreground | background |
|:-----------:|:------------:|
|<img src="https://user-images.githubusercontent.com/22259776/83362102-9a421f00-a3c9-11ea-8c3f-5350d64520db.GIF"/>|<img src="https://user-images.githubusercontent.com/22259776/83362112-a4fcb400-a3c9-11ea-8881-0a25c640b9ba.GIF"/>|

## Other
~There is a bug that `onBackgroundMessage` fires after two or three minutes if you receive a notification in background and display an incoming call screen and send another notification after rejecting it.
I couldn't figure out what caused it.
Also, please point out any corrections to the source code to me.~
https://github.com/doneservices/flutter_callkeep/pull/14#issuecomment-645104936

