### PR TITLE
Fix missing PendingIntent immutability flag on Android API 31+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+- (android) Fix PendingIntent missing mutability flag error on API 31+
+
 ## 0.2.2
 
 - (android) Fix override parameters for Flutter 3.0 support

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/src/main/kotlin/co/doneservices/callkeep/CallKeep.kt
+++ b/android/src/main/kotlin/co/doneservices/callkeep/CallKeep.kt
@@ -613,6 +613,6 @@ class CallKeep(private val channel: MethodChannel, private var applicationContex
     }
 
     private fun getPendingIntentActivity(context: Context?, id: Int, intent: Intent?, flag: Int): PendingIntent {
-        return PendingIntent.getActivity(context, id, intent, if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S )  PendingIntent.FLAG_MUTABLE or flag else flag)
+        return PendingIntent.getActivity(context, id, intent, if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE or flag else flag)
     }
 }

--- a/android/src/main/kotlin/co/doneservices/callkeep/CallKeep.kt
+++ b/android/src/main/kotlin/co/doneservices/callkeep/CallKeep.kt
@@ -14,6 +14,7 @@ import android.os.Bundle
 import android.telecom.*
 import android.telephony.TelephonyManager
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
@@ -428,7 +429,8 @@ class CallKeep(private val channel: MethodChannel, private var applicationContex
             notificationManager.createNotificationChannel(channel)
         }
 
-        val pendingIntent = PendingIntent.getActivity(applicationContext, 0, launchIntent, PendingIntent.FLAG_CANCEL_CURRENT)
+        val pendingIntent = getPendingIntentActivity(applicationContext, 0, launchIntent, PendingIntent.FLAG_CANCEL_CURRENT)
+
         val builder = NotificationCompat.Builder(applicationContext, "incoming_calls")
 
         builder.setSmallIcon(applicationContext.resources.getIdentifier(icon, "drawable", applicationContext.packageName))
@@ -444,8 +446,8 @@ class CallKeep(private val channel: MethodChannel, private var applicationContex
         }
 
         builder.setContentTitle(contentTitle)
-        builder.addAction(0, declineText, PendingIntent.getActivity(applicationContext, 1, declineIntent, PendingIntent.FLAG_CANCEL_CURRENT))
-        builder.addAction(0, answerText, PendingIntent.getActivity(applicationContext, 2, answerIntent, PendingIntent.FLAG_CANCEL_CURRENT))
+        builder.addAction(0, declineText, getPendingIntentActivity(applicationContext, 1, declineIntent, PendingIntent.FLAG_CANCEL_CURRENT))
+        builder.addAction(0, answerText, getPendingIntentActivity(applicationContext, 2, answerIntent, PendingIntent.FLAG_CANCEL_CURRENT))
 
         notificationManager.notify(NOTIFICATION_ID, builder.build())
     }
@@ -608,5 +610,13 @@ class CallKeep(private val channel: MethodChannel, private var applicationContex
         hasPhoneAccountResult = null
 
         return true
+    }
+
+    fun getPendingIntentActivity(context: Context?, id: Int, intent: Intent?, flag: Int): PendingIntent {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            PendingIntent.getActivity(context, id, intent, PendingIntent.FLAG_MUTABLE or flag)
+        } else {
+            PendingIntent.getActivity(context, id, intent, flag)
+        }
     }
 }

--- a/android/src/main/kotlin/co/doneservices/callkeep/CallKeep.kt
+++ b/android/src/main/kotlin/co/doneservices/callkeep/CallKeep.kt
@@ -613,10 +613,6 @@ class CallKeep(private val channel: MethodChannel, private var applicationContex
     }
 
     private fun getPendingIntentActivity(context: Context?, id: Int, intent: Intent?, flag: Int): PendingIntent {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.getActivity(context, id, intent, PendingIntent.FLAG_MUTABLE or flag)
-        } else {
-            PendingIntent.getActivity(context, id, intent, flag)
-        }
+        return PendingIntent.getActivity(context, id, intent, if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S )  PendingIntent.FLAG_MUTABLE or flag else flag)
     }
 }

--- a/android/src/main/kotlin/co/doneservices/callkeep/CallKeep.kt
+++ b/android/src/main/kotlin/co/doneservices/callkeep/CallKeep.kt
@@ -612,7 +612,7 @@ class CallKeep(private val channel: MethodChannel, private var applicationContex
         return true
     }
 
-    fun getPendingIntentActivity(context: Context?, id: Int, intent: Intent?, flag: Int): PendingIntent {
+    private fun getPendingIntentActivity(context: Context?, id: Int, intent: Intent?, flag: Int): PendingIntent {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             PendingIntent.getActivity(context, id, intent, PendingIntent.FLAG_MUTABLE or flag)
         } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_callkeep
 description: iOS CallKit and Android ConnectionService bindings for Flutter
-version: 0.2.2
+version: 0.2.3
 homepage: https://github.com/doneservices/flutter_callkeep
 
 environment:


### PR DESCRIPTION
Setting the mutability flag for `PendingIntent`s is required from API 31 onward, the changes in this PR resolve this issue as it was throwing `IllegalArgumentException`:
https://sentry.io/organizations/done-services/issues/3497297862/?referrer=slack

For more info regarding `PendingIntent`s:
https://developer.android.com/reference/android/app/PendingIntent