### PR TITLE
Fix call management on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- Improve calls management on iOS implementation
+
 ## 0.3.0
 
 - Rework API based on `flutter_callkit_incoming`'s API, add iOS implementation and fix bugs (BREAKING CHANGE)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_callkeep
 description: iOS CallKit and Android ConnectionService bindings for Flutter
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/doneservices/flutter_callkeep
 
 # To avoid publishing errors


### PR DESCRIPTION
* Send correct data through the event channel for the call on which the action is being executed rather than the data on `SwiftCallKeepPlugin`.
* Fix endCall to only end the actual call that it gets from Flutter rather than the `data` on the `SwiftCallKeepPlugin`, this was causing an accepted call to be ended for instance if the user accepts an incoming call & declines a current call through CallKit.
* Stop removing and declining all calls when the audio session is deactivated, as this may happen when accepting and declining a call.