### PR TITLE
[iOS] Clear outgoing and answerCall properly

### DIFF
--- a/ios/Classes/SwiftCallKeepPlugin.swift
+++ b/ios/Classes/SwiftCallKeepPlugin.swift
@@ -404,6 +404,7 @@ public class SwiftCallKeepPlugin: NSObject, FlutterPlugin, CXProviderDelegate {
             sendEvent(SwiftCallKeepPlugin.ACTION_CALL_ENDED, call.data.toJSON())
             action.fulfill()
         }
+        // We clear the cached outgoing or answered call based on which call has ended 
         if(call === self.outgoingCall) {self.outgoingCall = nil}
         if(call === self.answerCall) {self.answerCall = nil}
     }

--- a/ios/Classes/SwiftCallKeepPlugin.swift
+++ b/ios/Classes/SwiftCallKeepPlugin.swift
@@ -404,6 +404,8 @@ public class SwiftCallKeepPlugin: NSObject, FlutterPlugin, CXProviderDelegate {
             sendEvent(SwiftCallKeepPlugin.ACTION_CALL_ENDED, call.data.toJSON())
             action.fulfill()
         }
+        if(call === self.outgoingCall) {self.outgoingCall = nil}
+        if(call === self.answerCall) {self.answerCall = nil}
     }
     
     


### PR DESCRIPTION
Otherwise, we would get that there is an answered call when there isn't as the cached call is not cleared properly, this caused some issues in iOS where we try to answer an outgoing call, which caused the call to fail before it connects.