### PR TITLE
-- Fix for Android SDK 34 Crash due to missing flag RECEIVER_EXPORTED .

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 32
+    compileSdk 34
 
     namespace 'co.doneservices.callkeep'
 
@@ -33,9 +33,10 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdk 28
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-rules.pro'
+        targetSdk 34
     }
     lintOptions {
         disable 'InvalidPackage'
@@ -43,11 +44,11 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    //implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'de.hdodenhof:circleimageview:3.1.0'
     implementation 'com.squareup.picasso:picasso:2.71828'
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
-    implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
+    implementation 'com.google.code.gson:gson:2.10.1'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip

--- a/android/src/main/kotlin/co/doneservices/callkeep/IncomingCallActivity.kt
+++ b/android/src/main/kotlin/co/doneservices/callkeep/IncomingCallActivity.kt
@@ -107,10 +107,20 @@ class IncomingCallActivity : Activity() {
         setContentView(R.layout.activity_call_incoming)
         initView()
         updateViewWithIncomingIntentData(intent)
-        registerReceiver(
-                endedCallKeepBroadcastReceiver,
-                IntentFilter("${packageName}.${ACTION_ENDED_CALL_INCOMING}")
-        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(
+                    endedCallKeepBroadcastReceiver,
+                    IntentFilter("${packageName}.${ACTION_ENDED_CALL_INCOMING}"),
+                    RECEIVER_EXPORTED
+            )
+        }
+        else
+        {
+            registerReceiver(
+                    endedCallKeepBroadcastReceiver,
+                    IntentFilter("${packageName}.${ACTION_ENDED_CALL_INCOMING}"),
+            )
+        }
     }
 
     private fun wakeLockRequest(duration: Long) {


### PR DESCRIPTION
-- Fix for Android SDK 34 Crash due to missing flag RECEIVER_EXPORTED .
-- changes in gradlefile.
-- updated minimum SDK version and specified target SDK version.

closes #66 